### PR TITLE
Avoid double slash in url

### DIFF
--- a/internal/email/client.go
+++ b/internal/email/client.go
@@ -26,7 +26,7 @@ func (c *Client) getEndpoint() string {
 	if c.Endpoint != "" {
 		return c.Endpoint
 	}
-	c.Endpoint = fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com/", c.APIID, c.Region)
+	c.Endpoint = fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com", c.APIID, c.Region)
 
 	if c.Verbose {
 		fmt.Printf("[DEBUG] Generated endpoint: %s\n", c.Endpoint)

--- a/internal/email/client_test.go
+++ b/internal/email/client_test.go
@@ -25,10 +25,10 @@ func TestGetEndpoint(t *testing.T) {
 	}{
 		{
 			client: Client{
-				Endpoint: "https://api_id.execute-api.us-west-2.amazonaws.com/",
+				Endpoint: "https://api_id.execute-api.us-west-2.amazonaws.com",
 				Verbose:  true,
 			},
-			endpoint: "https://api_id.execute-api.us-west-2.amazonaws.com/",
+			endpoint: "https://api_id.execute-api.us-west-2.amazonaws.com",
 		},
 		{
 			client: Client{
@@ -36,7 +36,7 @@ func TestGetEndpoint(t *testing.T) {
 				Region:  "us-west-2",
 				Verbose: true,
 			},
-			endpoint: "https://api_id.execute-api.us-west-2.amazonaws.com/",
+			endpoint: "https://api_id.execute-api.us-west-2.amazonaws.com",
 		},
 	}
 


### PR DESCRIPTION
Avoid `https://api.com//emails`